### PR TITLE
Add systemd example to run tunnelx in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 TunnelX is a lightweight ingress tunneling tool designed to create a secure SOCKS5 proxy server for routing network traffic. TunnelX is created for enabling internal network scanning from the [ProjectDiscovery platform](https://cloud.projectdiscovery.io/scans), ensuring a seamless and isolated connection.
 
 ## Features
+
 - Secure network ingress via SOCKS5 proxy.
 - Authenticated connections using your [ProjectDiscovery API key](https://cloud.projectdiscovery.io/?ref=api_key).
 - Isolated traffic routing for internal scanning and discovery.
-
 
 ## How It Works
 
@@ -19,54 +19,67 @@ You can run TunnelX on different networks by specifying unique network names. Th
 ### Docker (Recommended)
 
 1. **Run the Docker image:**
-    ```sh
-    docker run --network host -d -e PDCP_API_KEY="your_api_key" projectdiscovery/tunnelx:latest
-    ```
-    Replace `your_api_key` with your ProjectDiscovery API key.
+
+   ```sh
+   docker run --network host -d -e PDCP_API_KEY="your_api_key" projectdiscovery/tunnelx:latest
+   ```
+
+   Replace `your_api_key` with your ProjectDiscovery API key.
 
 2. **Alternatively, build and run locally:**
-    ```sh
-    docker build . -t tunnelx
-    docker run --network host -d -e PDCP_API_KEY="your_api_key" tunnelx
-    ```
+   ```sh
+   docker build . -t tunnelx
+   docker run --network host -d -e PDCP_API_KEY="your_api_key" tunnelx
+   ```
 
 ### Go
 
 1. **Install and run:**
-    ```sh
-    go install github.com/projectdiscovery/tunnelx@latest
-    export PDCP_API_KEY="your_api_key"
-    tunnelx
-    ```
+
+   ```sh
+   go install github.com/projectdiscovery/tunnelx@latest
+   export PDCP_API_KEY="your_api_key"
+   tunnelx
+   ```
 
 2. **Run directly from source:**
-    ```sh
-    git clone https://github.com/projectdiscovery/tunnelx.git
-    cd tunnelx
-    export PDCP_API_KEY="your_api_key"
-    go run .
-    ```
 
-3. After successful connection, navigate to [ProjectDiscovery Scans](https://cloud.projectdiscovery.io/scans) to create and manage scans using the established connection.
+   ```sh
+   git clone https://github.com/projectdiscovery/tunnelx.git
+   cd tunnelx
+   export PDCP_API_KEY="your_api_key"
+   go run .
+   ```
+
+3. **Run as a systemd service: If you want to run TunnelX under systemd:**
+   Update the deployment/systemd/tunnelx.service file: - Set Environment="PDCP_API_KEY=your_api_key_here" - Add your username under User= and set WorkingDirectory= to the TunnelX directory.
+   Copy and enable the service:
+   `sudo cp deployment/systemd/tunnelx.service /etc/systemd/system/tunnelx.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable tunnelx
+    sudo systemctl start tunnelx`
+
+4. After successful connection, navigate to [ProjectDiscovery Scans](https://cloud.projectdiscovery.io/scans) to create and manage scans using the established connection.
 
 ![Internal Network](https://github.com/user-attachments/assets/d6e58159-3c2d-4902-a0a9-64d6f07da64c)
-
 
 ## Command-Line Usage
 
 ### Flags
 
-| Flag        | Description                                                 |
-|-------------|-------------------------------------------------------------|
-| `-auth`     | Your ProjectDiscovery API key (required).                   |
-| `-name`     | (Optional) Specify a custom network name. Default is your machine’s hostname. |
+| Flag    | Description                                                                   |
+| ------- | ----------------------------------------------------------------------------- |
+| `-auth` | Your ProjectDiscovery API key (required).                                     |
+| `-name` | (Optional) Specify a custom network name. Default is your machine’s hostname. |
 
 **Example:**
+
 ```sh
 tunnelx -auth <your_api_key> -name <custom_network_name>
 ```
 
 **Output Example:**
+
 ```sh
 tunnelx -auth <your_api_key>
 

--- a/deployment/systemd/tunnelx.service
+++ b/deployment/systemd/tunnelx.service
@@ -1,0 +1,43 @@
+
+# ------------------------
+# TunnelX systemd service
+# ------------------------
+
+[Unit]
+# Description of the service (shows up in systemctl status)
+Description=TunnelX - Secure Ingress Tunneling Service
+
+# Ensure TunnelX starts only after the network is up
+After=network.target
+
+[Service]
+# The service runs in the foreground (doesn't fork itself)
+Type=simple
+
+# Set environment variables used by TunnelX (API key for authentication)
+Environment="PDCP_API_KEY=your_api_key_here"
+
+# Command to start TunnelX, using the environment variable defined above
+# ExecStart path to the tunnelx binary
+ExecStart=/home/username/tunnelx/tunnelx -auth ${PDCP_API_KEY}
+
+# Restart the service automatically if it crashes
+Restart=on-failure
+
+# Delay (in seconds) before attempting restart after failure
+RestartSec=5
+
+# The user under which the service will run (must have permissions to execute the binary)
+User=username
+
+# Working directory for the service — used for relative file paths or logging if applicable
+WorkingDirectory=/home/username/tunnelx
+
+[Install]
+# Specifies when the service should be started — in this case, during normal system boot
+WantedBy=multi-user.target
+
+
+
+
+


### PR DESCRIPTION
Created the systemd file under deployment dir, with changes in readme file to how to use and run the tunnelx service under systemd